### PR TITLE
Solve issue when looking for GNU readline lib headers

### DIFF
--- a/configure
+++ b/configure
@@ -1477,37 +1477,6 @@ fi
 
 } # ac_fn_c_try_link
 
-# ac_fn_c_check_header_compile LINENO HEADER VAR INCLUDES
-# -------------------------------------------------------
-# Tests whether HEADER exists and can be compiled using the include files in
-# INCLUDES, setting the cache variable VAR accordingly.
-ac_fn_c_check_header_compile ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-$as_echo_n "checking for $2... " >&6; }
-if eval \${$3+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$4
-#include <$2>
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  eval "$3=yes"
-else
-  eval "$3=no"
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-eval ac_res=\$$3
-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-$as_echo "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_c_check_header_compile
-
 # ac_fn_c_try_cpp LINENO
 # ----------------------
 # Try to preprocess conftest.$ac_ext, and return whether this succeeded.
@@ -1677,6 +1646,37 @@ fi
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_try_run
+
+# ac_fn_c_check_header_compile LINENO HEADER VAR INCLUDES
+# -------------------------------------------------------
+# Tests whether HEADER exists and can be compiled using the include files in
+# INCLUDES, setting the cache variable VAR accordingly.
+ac_fn_c_check_header_compile ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+#include <$2>
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$3=yes"
+else
+  eval "$3=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_header_compile
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -2981,71 +2981,6 @@ fi
   if test "$HAVE_LIBREADLINE" = "no"; then
     as_fn_error $? "GNU readline is not installed." "$LINENO" 5
   fi
-  for ac_header in readline/readline.h
-do :
-  ac_fn_c_check_header_compile "$LINENO" "readline/readline.h" "ac_cv_header_readline_readline_h" "HAVE_READLINE_H=no
-"
-if test "x$ac_cv_header_readline_readline_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_READLINE_READLINE_H 1
-_ACEOF
- readline/rlconf.h
-else
-  HAVE_READLINE_H=yes
-fi
-
-done
-
-  if test "$HAVE_READLINE_H" = "no"; then
-    as_fn_error $? "GNU readline development header is not installed." "$LINENO" 5
-  fi
-
-  ## OpenSSL
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSL_library_init in -lssl" >&5
-$as_echo_n "checking for SSL_library_init in -lssl... " >&6; }
-if ${ac_cv_lib_ssl_SSL_library_init+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lssl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char SSL_library_init ();
-int
-main ()
-{
-return SSL_library_init ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_ssl_SSL_library_init=yes
-else
-  ac_cv_lib_ssl_SSL_library_init=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssl_SSL_library_init" >&5
-$as_echo "$ac_cv_lib_ssl_SSL_library_init" >&6; }
-if test "x$ac_cv_lib_ssl_SSL_library_init" = xyes; then :
-  HAVE_LIBSSL=yes
-else
-  HAVE_LIBSSL=no
-fi
-
-  if test "$HAVE_LIBSSL" = "no"; then
-    as_fn_error $? "OpenSSL is not installed." "$LINENO" 5
-  fi
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -3443,7 +3378,118 @@ fi
 done
 
 
-for ac_header in openssl/ssl.h
+for ac_header in readline/readline.h, readline/rlconf.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+ HAVE_READLINE_H=yes
+else
+  HAVE_READLINE_H=no
+fi
+
+done
+
+  if test "$HAVE_READLINE_H" = "no"; then
+    as_fn_error $? "GNU readline development header is not installed." "$LINENO" 5
+  fi
+
+  ## OpenSSL
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSL_library_init in -lssl" >&5
+$as_echo_n "checking for SSL_library_init in -lssl... " >&6; }
+if ${ac_cv_lib_ssl_SSL_library_init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lssl  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char SSL_library_init ();
+int
+main ()
+{
+return SSL_library_init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_ssl_SSL_library_init=yes
+else
+  ac_cv_lib_ssl_SSL_library_init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssl_SSL_library_init" >&5
+$as_echo "$ac_cv_lib_ssl_SSL_library_init" >&6; }
+if test "x$ac_cv_lib_ssl_SSL_library_init" = xyes; then :
+  HAVE_LIBSSL=yes
+else
+  HAVE_LIBSSL=no
+fi
+
+  if test "$HAVE_LIBSSL" = "no"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: OpenSSL <1.1 not installed. Checking v1.1 or beyond..." >&5
+$as_echo "$as_me: WARNING: OpenSSL <1.1 not installed. Checking v1.1 or beyond..." >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OPENSSL_init_ssl in -lssl" >&5
+$as_echo_n "checking for OPENSSL_init_ssl in -lssl... " >&6; }
+if ${ac_cv_lib_ssl_OPENSSL_init_ssl+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lssl  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char OPENSSL_init_ssl ();
+int
+main ()
+{
+return OPENSSL_init_ssl ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_ssl_OPENSSL_init_ssl=yes
+else
+  ac_cv_lib_ssl_OPENSSL_init_ssl=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssl_OPENSSL_init_ssl" >&5
+$as_echo "$ac_cv_lib_ssl_OPENSSL_init_ssl" >&6; }
+if test "x$ac_cv_lib_ssl_OPENSSL_init_ssl" = xyes; then :
+  HAVE_LIBSSL=yes
+else
+  HAVE_LIBSSL=no
+fi
+
+    if test "$HAVE_LIBSSL" = "no"; then
+      as_fn_error $? "OpenSSL is not installed." "$LINENO" 5
+    fi
+  fi
+  for ac_header in openssl/ssl.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "openssl/ssl.h" "ac_cv_header_openssl_ssl_h" "$ac_includes_default"
 if test "x$ac_cv_header_openssl_ssl_h" = xyes; then :

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ if ( test -n "$WITH_CPYTHON" || test -n "$WITH_PYPY" || test -n "$WITH_STACKLESS
   if test "$HAVE_LIBREADLINE" = "no"; then
     AC_MSG_ERROR([GNU readline is not installed.])
   fi
-  AC_CHECK_HEADERS(readline/readline.h, readline/rlconf.h, [HAVE_READLINE_H=yes], [HAVE_READLINE_H=no])
+  AC_CHECK_HEADERS([readline/readline.h, readline/rlconf.h], [HAVE_READLINE_H=yes], [HAVE_READLINE_H=no], [])
   if test "$HAVE_READLINE_H" = "no"; then
     AC_MSG_ERROR([GNU readline development header is not installed.])
   fi
@@ -36,6 +36,7 @@ if ( test -n "$WITH_CPYTHON" || test -n "$WITH_PYPY" || test -n "$WITH_STACKLESS
   ## OpenSSL
   AC_CHECK_LIB(ssl, SSL_library_init, [HAVE_LIBSSL=yes], [HAVE_LIBSSL=no])
   if test "$HAVE_LIBSSL" = "no"; then
+    AC_MSG_WARN([OpenSSL <1.1 not installed. Checking v1.1 or beyond...])
     AC_CHECK_LIB(ssl, OPENSSL_init_ssl, [HAVE_LIBSSL=yes], [HAVE_LIBSSL=no])
     if test "$HAVE_LIBSSL" = "no"; then
       AC_MSG_ERROR([OpenSSL is not installed.])


### PR DESCRIPTION
At least true for GNU autoconf 2.69 (the release used for years), the `AC_CHECK_HEADERS` macro utilized to look for the GNU readline library headers was malformed, thus provoking two consequences:
1. Error at compilation time as a defective C preprocessor instruction was always included:

```
conftest.c:9:1: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]
HAVE_READLINE_H=no
^
conftest.c:9:17: error: use of undeclared identifier 'no'
HAVE_READLINE_H=no
                ^
conftest.c:9:19: error: expected ';' after top level declarator
HAVE_READLINE_H=no
                  ^
```       
2. Regardless of whether the headers were found or not,  the code was giving the condition as satisfied since `HAVE_LIBREADLINE_H` variable was never assigned `no`, but `yes`, despite the (always) negative result of the test:
 
```
(...)
| #include <readline/readline.h>
configure:2986: result: no
configure:3004: checking for SSL_library_init in -lssl
(...)
```      

In conclusion, `pyenv-doctor` was not properly testing for GNU readline lib headers.