### PR TITLE
Allow Homebrew openssl@1.1 on Mac

### DIFF
--- a/bin/pyenv-doctor
+++ b/bin/pyenv-doctor
@@ -157,8 +157,10 @@ case "$(uname -s)" in
   if command -v brew 1>/dev/null 2>&1; then # Homebrew
     [ -d "$(brew --prefix)/include" ] && export CPPFLAGS="-I$(brew --prefix)/include $CPPFLAGS"
     [ -d "$(brew --prefix openssl)/include" ] && export CPPFLAGS="-I$(brew --prefix openssl)/include $CPPFLAGS"
+    [ -d "$(brew --prefix openssl@1.1)/include" ] && export CPPFLAGS="-I$(brew --prefix openssl@1.1)/include $CPPFLAGS"
     [ -d "$(brew --prefix)/lib" ] && export LDFLAGS="-L$(brew --prefix)/lib $LDFLAGS"
     [ -d "$(brew --prefix openssl)/lib" ] && export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
+    [ -d "$(brew --prefix openssl@1.1)/lib" ] && export LDFLAGS="-L$(brew --prefix openssl@1.1)/lib $LDFLAGS"
   fi
   ;;
 esac


### PR DESCRIPTION
I continue to get errors in similar situation as #7.
`pyenv doctor` fails with a warning about specified OpenSSL is not installed.

```sh
❯ pyenv doctor
Cloning /Users/kotokaze/.tools/anyenv/envs/pyenv/plugins/pyenv-doctor/bin/.....
Installing python-pyenv-doctor...
python-build: use readline from homebrew
python-build: use zlib from xcode sdk

BUILD FAILED (OS X 12.2.1 using python-build 2.2.5-9-g72757562)

Inspect or clean up the working tree at /var/folders/.../T/python-build.20220328001614.67613
Results logged to /var/folders/.../T/python-build.20220328001614.67613.log

Last 10 log lines:
checking readline/readline.h, presence... no
checking for readline/readline.h,... no
checking readline/rlconf.h usability... yes
checking readline/rlconf.h presence... yes
checking for readline/rlconf.h... yes
checking for SSL_library_init in -lssl... no
configure: WARNING: OpenSSL <1.1 not installed. Checking v1.1 or beyond...
checking for OPENSSL_init_ssl in -lssl... no
configure: error: OpenSSL is not installed.
make: *** No targets specified and no makefile found.  Stop.
Problem(s) detected while checking system.

See https://github.com/pyenv/pyenv/wiki/Common-build-problems for known solutions.
```

This request solves the problem, and  now works fine.
```sh
❯ pyenv doctor
Cloning /Users/kotokaze/.tools/anyenv/envs/pyenv/plugins/pyenv-doctor/bin/.....
Installing python-pyenv-doctor...
python-build: use readline from homebrew
python-build: use zlib from xcode sdk
Installed python-pyenv-doctor to /var/folders/.../T/pyenv-doctor.20220328005654.82008/prefix

Congratulations! You are ready to build pythons!
```