### PR TITLE
Change the `pyenv-doctor` clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and development tools to build pythons.
 Installing pyenv-doctor as a pyenv plugin will give you access to the
 `pyenv doctor` command.
 
-    $ git clone git://github.com/pyenv/pyenv-doctor.git $(pyenv root)/plugins/pyenv-doctor
+    $ git clone git://github.com:pyenv/pyenv-doctor.git $(pyenv root)/plugins/pyenv-doctor
 
 ## Usage
 


### PR DESCRIPTION
Github has removed support for unauthenticated git clones, so I think it needs to be an HTTP clone instead to allow unauthenticated users to clone the doctor repo